### PR TITLE
Image index in location hash

### DIFF
--- a/src/domtools.js
+++ b/src/domtools.js
@@ -6,11 +6,11 @@ function isIE() {
 
 function byIds(ids) {
   return utils.mapForKeys(ids, byId);
-};
+}
 
 function byId(id) {
   return window.document.getElementById(id);
-};
+}
 
 function byClass(className) {
   return window.document.getElementsByClassName(className);
@@ -163,6 +163,14 @@ function ajax(opts) {
   }
 }
 
+function setHashLocation(l) {
+  window.location = '#' + l;
+}
+
+function getHashLocation() {
+  return window.location.hash.substring(1);
+}
+
 exports.byIds = byIds;
 exports.byId = byId;
 exports.byClass = byClass;
@@ -183,3 +191,6 @@ exports.toggleCssClass = toggleCssClass;
 exports.hide = hide;
 exports.show = show;
 exports.clearNode = clearNode;
+exports.setHashLocation = setHashLocation;
+exports.getHashLocation = getHashLocation;
+

--- a/src/gallery.js
+++ b/src/gallery.js
@@ -6,11 +6,11 @@ function Gallery(display, imageFactory) {
   var images = new StateList();
   var zoom = new StateList(['min', 'med', 'max']);
 
-  self.initialize = function(urls) {
+  self.initialize = function(urls, selectedImageIndex) {
     setNoImagesWarning(urls.length === 0);
     images.setList(createImages(urls));
     display.setImages(images.list);
-    showCurrentImage();
+    self.setIndex(selectedImageIndex);
   };
 
   function setNoImagesWarning(visible) {
@@ -47,9 +47,17 @@ function Gallery(display, imageFactory) {
   }
 
   function setImageInfo() {
-    var current = images.currentIndex + 1;
-    var total = images.lastIndex() + 1;
-    display.setImageInfoHtml(current + "/" + total);
+    var index = currentIndex();
+    display.setImageLocation(index);
+    display.setImageInfoHtml(index + '/' + lastIndex());
+  }
+
+  function currentIndex() {
+    return images.currentIndex + 1;
+  }
+
+  function lastIndex() {
+    return images.lastIndex() + 1;
   }
 
   function isMaxZoom() {
@@ -83,6 +91,12 @@ function Gallery(display, imageFactory) {
 
   self.setNextZoom = function() {
     display.setZoom(zoom.next());
+  };
+
+  self.setIndex = function(index) {
+    hideCurrentImage();
+    images.setCurrentIndex(index);
+    showCurrentImage();
   };
 
   display.addNextHandler(self.next);

--- a/src/main.js
+++ b/src/main.js
@@ -13,8 +13,13 @@
 
   function loadGallery(images) {
     display.initialize();
-    gallery.initialize(images);
+    gallery.initialize(images, getImageIndex());
     window.kuvia = gallery;
+  }
+
+  function getImageIndex() {
+    var hash = domtools.getHashLocation();
+    return parseInt(hash) - 1 || 0;
   }
 
   function loadAjaxGallery(url) {
@@ -37,5 +42,9 @@
     } else {
       loadGallery([]);
     }
+  });
+
+  domtools.onEvent(window, "hashchange", function() {
+    gallery.setIndex(getImageIndex());
   });
 }());

--- a/src/statelist.js
+++ b/src/statelist.js
@@ -13,11 +13,11 @@ function StateList(listItems) {
   };
 
   self.next = function() {
-    setCurrentIndex(self.currentIndex + 1, 0);
+    setIndex(self.currentIndex + 1, 0);
     return self.currentItem();
   };
 
-  function setCurrentIndex(index, fallback) {
+  function setIndex(index, fallback) {
     if (isIndexOutOfBounds(index)) {
       self.currentIndex = fallback;
     } else {
@@ -34,13 +34,17 @@ function StateList(listItems) {
   };
 
   self.previous = function() {
-    setCurrentIndex(self.currentIndex - 1, self.lastIndex());
+    setIndex(self.currentIndex - 1, self.lastIndex());
     return self.currentItem();
   };
 
   self.setCurrentItem = function(item) {
     var index = self.list.indexOf(item);
-    setCurrentIndex(index, self.currentIndex);
+    self.setCurrentIndex(index);
+  };
+
+  self.setCurrentIndex = function(index) {
+    setIndex(index, self.currentIndex);
   };
 
   self.removeCurrent = function() {

--- a/src/view.js
+++ b/src/view.js
@@ -102,6 +102,10 @@ var createView = function() {
     dom.addCssClass(elements.imgarea, 'zoom-' + zoomMode);
   };
 
+  self.setImageLocation = function(l) {
+    dom.setHashLocation(l);
+  };
+
   return self;
 };
 


### PR DESCRIPTION
The current image index is placed in the hash of the page. This allows
jumping directly to a certain image in the gallery from external links.
The feature also makes it possible to use browser's back and forward
keys to jump between images.
